### PR TITLE
[ENH] JS Client Refactor Part 3 - Update tests to use new interface

### DIFF
--- a/clients/js/src/ChromaClient.ts
+++ b/clients/js/src/ChromaClient.ts
@@ -416,14 +416,10 @@ export class ChromaClient {
   async addRecords(
     collection: Collection,
     params: AddRecordsParams,
-  ): Promise<AddResponse> {
-    if (typeof params.ids === "string") {
-      throw new Error(
-        "To add a single record, use the singular field names (id, embedding, metadata, document) instead of the plural field names (ids, embeddings, metadatas, documents)",
-      );
-    }
+  ): Promise<void> {
     await this.init();
-    return await this.api.add(
+
+    await this.api.add(
       collection.id,
       // TODO: For some reason the auto generated code requires metadata to be defined here.
       (await prepareRecordRequest(
@@ -454,12 +450,8 @@ export class ChromaClient {
    * ```
    */
   async upsertRecords(collection: Collection, params: UpsertRecordsParams) {
-    if (typeof params.ids === "string") {
-      throw new Error(
-        "To upsert a single record, use the singular field names (id, embedding, metadata, document) instead of the plural field names (ids, embeddings, metadatas, documents)",
-      );
-    }
     await this.init();
+
     await this.api.upsert(
       collection.id,
       // TODO: For some reason the auto generated code requires metadata to be defined here.
@@ -491,15 +483,11 @@ export class ChromaClient {
    * ```
    */
   async updateRecords(collection: Collection, params: UpdateRecordsParams) {
-    if (typeof params.ids === "string") {
-      throw new Error(
-        "To update a single record, use the singular field names (id, embedding, metadata, document) instead of the plural field names (ids, embeddings, metadatas, documents)",
-      );
-    }
     await this.init();
+
     await this.api.update(
       collection.id,
-      await prepareRecordRequest(params, collection.embeddingFunction),
+      await prepareRecordRequest(params, collection.embeddingFunction, true),
       this.api.options,
     );
   }
@@ -532,6 +520,7 @@ export class ChromaClient {
     { ids, where, limit, offset, include, whereDocument }: BaseGetParams = {},
   ): Promise<GetResponse> {
     await this.init();
+
     const idsArray = ids ? toArray(ids) : undefined;
 
     const resp = (await this.api.aGet(

--- a/clients/js/test/add.collections.test.ts
+++ b/clients/js/test/add.collections.test.ts
@@ -11,30 +11,37 @@ import { InvalidCollectionError } from "../src/Errors";
 test("it should add single embeddings to a collection", async () => {
   await chroma.reset();
   const collection = await chroma.createCollection({ name: "test" });
-  const ids = "test1";
-  const embeddings = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-  const metadatas = { test: "test" };
-  await collection.add({ ids, embeddings, metadatas });
-  const count = await collection.count();
+  const id = "test1";
+  const embedding = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+  const metadata = { test: "test" };
+  await chroma.addRecords(collection, {
+    id,
+    embedding,
+    metadata,
+  });
+  const count = await chroma.countRecords(collection);
   expect(count).toBe(1);
-  var res = await collection.get({
-    ids: [ids],
+  var res = await chroma.getRecords(collection, {
+    id,
     include: [IncludeEnum.Embeddings],
   });
-  expect(res.embeddings![0]).toEqual(embeddings);
+  expect(res.embedding).toEqual(embedding);
 });
 
 test("it should add batch embeddings to a collection", async () => {
   await chroma.reset();
   const collection = await chroma.createCollection({ name: "test" });
-  await collection.add({ ids: IDS, embeddings: EMBEDDINGS });
-  const count = await collection.count();
-  expect(count).toBe(3);
-  var res = await collection.get({
+  await chroma.addRecords(collection, {
     ids: IDS,
+    embeddings: EMBEDDINGS,
+    documents: DOCUMENTS,
+  });
+  const count = await chroma.countRecords(collection);
+  expect(count).toBe(3);
+  var res = await chroma.getRecords(collection, {
     include: [IncludeEnum.Embeddings],
   });
-  expect(res.embeddings).toEqual(EMBEDDINGS); // reverse because of the order of the ids
+  expect(res.embeddings).toEqual(EMBEDDINGS);
 });
 
 if (!process.env.OPENAI_API_KEY) {
@@ -50,10 +57,10 @@ if (!process.env.OPENAI_API_KEY) {
       embeddingFunction: embedder,
     });
     const embeddings = await embedder.generate(DOCUMENTS);
-    await collection.add({ ids: IDS, embeddings: embeddings });
-    const count = await collection.count();
+    await chroma.addRecords(collection, { ids: IDS, embeddings: embeddings });
+    const count = await chroma.countRecords(collection);
     expect(count).toBe(3);
-    var res = await collection.get({
+    var res = await chroma.getRecords(collection, {
       ids: IDS,
       include: [IncludeEnum.Embeddings],
     });
@@ -74,10 +81,10 @@ if (!process.env.COHERE_API_KEY) {
       embeddingFunction: embedder,
     });
     const embeddings = await embedder.generate(DOCUMENTS);
-    await collection.add({ ids: IDS, embeddings: embeddings });
-    const count = await collection.count();
+    await chroma.addRecords(collection, { ids: IDS, embeddings: embeddings });
+    const count = await chroma.countRecords(collection);
     expect(count).toBe(3);
-    var res = await collection.get({
+    var res = await chroma.getRecords(collection, {
       ids: IDS,
       include: [IncludeEnum.Embeddings],
     });
@@ -88,14 +95,14 @@ if (!process.env.COHERE_API_KEY) {
 test("add documents", async () => {
   await chroma.reset();
   const collection = await chroma.createCollection({ name: "test" });
-  let resp = await collection.add({
+  let resp = await chroma.addRecords(collection, {
     ids: IDS,
     embeddings: EMBEDDINGS,
     documents: DOCUMENTS,
   });
   expect(resp).toBe(true);
-  const results = await collection.get({ ids: ["test1"] });
-  expect(results.documents[0]).toBe("This is a test");
+  const results = await chroma.getRecords(collection, { id: "test1" });
+  expect(results.document).toBe("This is a test");
 });
 
 test("should error on non existing collection", async () => {
@@ -103,7 +110,7 @@ test("should error on non existing collection", async () => {
   const collection = await chroma.createCollection({ name: "test" });
   await chroma.deleteCollection({ name: "test" });
   expect(async () => {
-    await collection.add({ ids: IDS, embeddings: EMBEDDINGS });
+    await chroma.addRecords(collection, { ids: IDS, embeddings: EMBEDDINGS });
   }).rejects.toThrow(InvalidCollectionError);
 });
 
@@ -114,7 +121,7 @@ test("It should return an error when inserting duplicate IDs in the same batch",
   const embeddings = EMBEDDINGS.concat([[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]]);
   const metadatas = METADATAS.concat([{ test: "test1", float_value: 0.1 }]);
   try {
-    await collection.add({ ids, embeddings, metadatas });
+    await chroma.addRecords(collection, { ids, embeddings, metadatas });
   } catch (e: any) {
     expect(e.message).toMatch("duplicates");
   }
@@ -127,7 +134,7 @@ test("should error on empty embedding", async () => {
   const embeddings = [[]];
   const metadatas = [{ test: "test1", float_value: 0.1 }];
   try {
-    await collection.add({ ids, embeddings, metadatas });
+    await chroma.addRecords(collection, { ids, embeddings, metadatas });
   } catch (e: any) {
     expect(e.message).toMatch("got empty embedding at pos");
   }
@@ -149,10 +156,10 @@ if (!process.env.OLLAMA_SERVER_URL) {
       embeddingFunction: embedder,
     });
     const embeddings = await embedder.generate(DOCUMENTS);
-    await collection.add({ ids: IDS, embeddings: embeddings });
-    const count = await collection.count();
+    await chroma.addRecords(collection, { ids: IDS, embeddings: embeddings });
+    const count = await chroma.countRecords(collection);
     expect(count).toBe(3);
-    var res = await collection.get({
+    var res = await chroma.getRecords(collection, {
       ids: IDS,
       include: [IncludeEnum.Embeddings],
     });

--- a/clients/js/test/add.collections.test.ts
+++ b/clients/js/test/add.collections.test.ts
@@ -15,17 +15,17 @@ test("it should add single embeddings to a collection", async () => {
   const embedding = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
   const metadata = { test: "test" };
   await chroma.addRecords(collection, {
-    id,
-    embedding,
-    metadata,
+    ids: id,
+    embeddings: embedding,
+    metadatas: metadata,
   });
   const count = await chroma.countRecords(collection);
   expect(count).toBe(1);
   var res = await chroma.getRecords(collection, {
-    id,
+    ids: id,
     include: [IncludeEnum.Embeddings],
   });
-  expect(res.embedding).toEqual(embedding);
+  expect(res.embeddings?.[0]).toEqual(embedding);
 });
 
 test("it should add batch embeddings to a collection", async () => {
@@ -95,14 +95,13 @@ if (!process.env.COHERE_API_KEY) {
 test("add documents", async () => {
   await chroma.reset();
   const collection = await chroma.createCollection({ name: "test" });
-  let resp = await chroma.addRecords(collection, {
+  await chroma.addRecords(collection, {
     ids: IDS,
     embeddings: EMBEDDINGS,
     documents: DOCUMENTS,
   });
-  expect(resp).toBe(true);
-  const results = await chroma.getRecords(collection, { id: "test1" });
-  expect(results.document).toBe("This is a test");
+  const results = await chroma.getRecords(collection, { ids: "test1" });
+  expect(results.documents[0]).toBe("This is a test");
 });
 
 test("should error on non existing collection", async () => {

--- a/clients/js/test/auth.basic.test.ts
+++ b/clients/js/test/auth.basic.test.ts
@@ -28,8 +28,8 @@ test("it should list collections", async () => {
   await client.reset();
   let collections = await client.listCollections();
   expect(collections).toBeDefined();
-  expect(collections).toBeInstanceOf(Array);
-  expect(collections.length).toBe(0);
+  expect(Array.isArray(collections)).toBe(true);
+  expect(collections).toHaveLength(0);
   await client.createCollection({ name: "test" });
   collections = await client.listCollections();
   expect(collections.length).toBe(1);

--- a/clients/js/test/auth.token.test.ts
+++ b/clients/js/test/auth.token.test.ts
@@ -31,13 +31,13 @@ if (process.env.XTOKEN_TEST) {
     await client.reset();
     let collections = await client.listCollections();
     expect(collections).toBeDefined();
-    expect(collections).toBeInstanceOf(Array);
-    expect(collections.length).toBe(0);
+    expect(Array.isArray(collections)).toBe(true);
+    expect(collections).toHaveLength(0);
     await client.createCollection({
       name: "test",
     });
     collections = await client.listCollections();
-    expect(collections.length).toBe(1);
+    expect(collections).toHaveLength(1);
   });
 } else {
   test.each([
@@ -48,12 +48,12 @@ if (process.env.XTOKEN_TEST) {
     await client.reset();
     let collections = await client.listCollections();
     expect(collections).toBeDefined();
-    expect(collections).toBeInstanceOf(Array);
-    expect(collections.length).toBe(0);
+    expect(Array.isArray(collections)).toBe(true);
+    expect(collections).toHaveLength(0);
     await client.createCollection({
       name: "test",
     });
     collections = await client.listCollections();
-    expect(collections.length).toBe(1);
+    expect(collections).toHaveLength(1);
   });
 }

--- a/clients/js/test/client.test.ts
+++ b/clients/js/test/client.test.ts
@@ -1,7 +1,6 @@
 import { expect, test } from "@jest/globals";
 import { ChromaClient } from "../src/ChromaClient";
 import chroma from "./initClient";
-import { ChromaValueError } from "../src/Errors";
 
 test("it should create the client connection", async () => {
   expect(chroma).toBeDefined();
@@ -24,184 +23,18 @@ test("it should reset the database", async () => {
   await chroma.reset();
   const collections = await chroma.listCollections();
   expect(collections).toBeDefined();
-  expect(collections).toBeInstanceOf(Array);
+  expect(Array.isArray(collections)).toBe(true);
   expect(collections.length).toBe(0);
 
-  const collection = await chroma.createCollection({ name: "test" });
+  await chroma.createCollection({ name: "test" });
   const collections2 = await chroma.listCollections();
   expect(collections2).toBeDefined();
-  expect(collections2).toBeInstanceOf(Array);
+  expect(Array.isArray(collections2)).toBe(true);
   expect(collections2.length).toBe(1);
 
   await chroma.reset();
   const collections3 = await chroma.listCollections();
   expect(collections3).toBeDefined();
-  expect(collections3).toBeInstanceOf(Array);
+  expect(Array.isArray(collections3)).toBe(true);
   expect(collections3.length).toBe(0);
-});
-
-test("it should list collections", async () => {
-  await chroma.reset();
-  let collections = await chroma.listCollections();
-  expect(collections).toBeDefined();
-  expect(collections).toBeInstanceOf(Array);
-  expect(collections.length).toBe(0);
-  const collection = await chroma.createCollection({ name: "test" });
-  collections = await chroma.listCollections();
-  expect(collections.length).toBe(1);
-});
-
-test("it should get a collection", async () => {
-  await chroma.reset();
-  const collection = await chroma.createCollection({ name: "test" });
-  const collection2 = await chroma.getCollection({ name: "test" });
-  expect(collection).toBeDefined();
-  expect(collection2).toBeDefined();
-  expect(collection).toHaveProperty("name");
-  expect(collection2).toHaveProperty("name");
-  expect(collection.name).toBe(collection2.name);
-  expect(collection).toHaveProperty("id");
-  expect(collection2).toHaveProperty("id");
-  expect(collection.id).toBe(collection2.id);
-});
-
-test("it should delete a collection", async () => {
-  await chroma.reset();
-  const collection = await chroma.createCollection({ name: "test" });
-  let collections = await chroma.listCollections();
-  expect(collections.length).toBe(1);
-  var resp = await chroma.deleteCollection({ name: "test" });
-  collections = await chroma.listCollections();
-  expect(collections.length).toBe(0);
-});
-
-test("it should add single embeddings to a collection", async () => {
-  await chroma.reset();
-  const collection = await chroma.createCollection({ name: "test" });
-  const ids = "test1";
-  const embeddings = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-  const metadatas = { test: "test" };
-  await collection.add({ ids, embeddings, metadatas });
-  const count = await collection.count();
-  expect(count).toBe(1);
-});
-
-test("it should add batch embeddings to a collection", async () => {
-  await chroma.reset();
-  const collection = await chroma.createCollection({ name: "test" });
-  const ids = ["test1", "test2", "test3"];
-  const embeddings = [
-    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-    [10, 9, 8, 7, 6, 5, 4, 3, 2, 1],
-  ];
-  await collection.add({ ids, embeddings });
-  const count = await collection.count();
-  expect(count).toBe(3);
-});
-
-test("it should query a collection", async () => {
-  await chroma.reset();
-  const collection = await chroma.createCollection({ name: "test" });
-  const ids = ["test1", "test2", "test3"];
-  const embeddings = [
-    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-    [10, 9, 8, 7, 6, 5, 4, 3, 2, 1],
-  ];
-  await collection.add({ ids, embeddings });
-  const results = await collection.query({
-    queryEmbeddings: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-    nResults: 2,
-  });
-  expect(results).toBeDefined();
-  expect(results).toBeInstanceOf(Object);
-  // expect(results.embeddings[0].length).toBe(2)
-  const result: string[] = ["test1", "test2"];
-  expect(result).toEqual(expect.arrayContaining(results.ids[0]));
-  expect(["test3"]).not.toEqual(expect.arrayContaining(results.ids[0]));
-});
-
-test("it should peek a collection", async () => {
-  await chroma.reset();
-  const collection = await chroma.createCollection({ name: "test" });
-  const ids = ["test1", "test2", "test3"];
-  const embeddings = [
-    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-    [10, 9, 8, 7, 6, 5, 4, 3, 2, 1],
-  ];
-  await collection.add({ ids, embeddings });
-  const results = await collection.peek({ limit: 2 });
-  expect(results).toBeDefined();
-  expect(results).toBeInstanceOf(Object);
-  expect(results.ids.length).toBe(2);
-  expect(["test1", "test2"]).toEqual(expect.arrayContaining(results.ids));
-});
-
-test("it should get a collection", async () => {
-  await chroma.reset();
-  const collection = await chroma.createCollection({ name: "test" });
-  const ids = ["test1", "test2", "test3"];
-  const embeddings = [
-    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-    [10, 9, 8, 7, 6, 5, 4, 3, 2, 1],
-  ];
-  const metadatas = [{ test: "test1" }, { test: "test2" }, { test: "test3" }];
-  await collection.add({ ids, embeddings, metadatas });
-  const results = await collection.get({ ids: ["test1"] });
-  expect(results).toBeDefined();
-  expect(results).toBeInstanceOf(Object);
-  expect(results.ids.length).toBe(1);
-  expect(["test1"]).toEqual(expect.arrayContaining(results.ids));
-  expect(["test2"]).not.toEqual(expect.arrayContaining(results.ids));
-
-  const results2 = await collection.get({ where: { test: "test1" } });
-  expect(results2).toBeDefined();
-  expect(results2).toBeInstanceOf(Object);
-  expect(results2.ids.length).toBe(1);
-});
-
-test("it should delete a collection", async () => {
-  await chroma.reset();
-  const collection = await chroma.createCollection({ name: "test" });
-  const ids = ["test1", "test2", "test3"];
-  const embeddings = [
-    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-    [10, 9, 8, 7, 6, 5, 4, 3, 2, 1],
-  ];
-  const metadatas = [{ test: "test1" }, { test: "test2" }, { test: "test3" }];
-  await collection.add({ ids, embeddings, metadatas });
-  let count = await collection.count();
-  expect(count).toBe(3);
-  var resp = await collection.delete({ where: { test: "test1" } });
-  count = await collection.count();
-  expect(count).toBe(2);
-});
-
-test("wrong code returns an error", async () => {
-  await chroma.reset();
-  const collection = await chroma.createCollection({ name: "test" });
-  const ids = ["test1", "test2", "test3"];
-  const embeddings = [
-    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-    [10, 9, 8, 7, 6, 5, 4, 3, 2, 1],
-  ];
-  const metadatas = [{ test: "test1" }, { test: "test2" }, { test: "test3" }];
-  await collection.add({ ids, embeddings, metadatas });
-  try {
-    await collection.get({
-      // @ts-ignore - supposed to fail
-      where: { test: { $contains: "hello" } },
-    });
-  } catch (e: any) {
-    expect(e).toBeDefined();
-    expect(e).toBeInstanceOf(ChromaValueError);
-    expect(e.message).toMatchInlineSnapshot(
-      `"Expected where operator to be one of $gt, $gte, $lt, $lte, $ne, $eq, $in, $nin, got $contains"`,
-    );
-  }
 });

--- a/clients/js/test/collection.client.test.ts
+++ b/clients/js/test/collection.client.test.ts
@@ -23,21 +23,19 @@ test("it should create a collection", async () => {
   expect(collection.name).toBe("test");
   let collections = await chroma.listCollections();
 
-  expect([
-    {
-      name: "test",
-      metadata: null,
-      id: collection.id,
-      database: "default_database",
-      tenant: "default_tenant",
-      version: 0,
-      dimension: null,
-    },
-  ]).toEqual(
-    expect.arrayContaining(
-      collections.map(({ configuration_json, ...rest }) => rest),
-    ),
-  );
+  expect(collections).toMatchInlineSnapshot(`
+    [
+      {
+        "database": "default_database",
+        "dimension": null,
+        "id": "${collection.id}",
+        "metadata": null,
+        "name": "test",
+        "tenant": "default_tenant",
+        "version": 0,
+      },
+    ]
+  `);
 
   expect([{ name: "test2", metadata: null }]).not.toEqual(
     expect.arrayContaining(collections),
@@ -56,21 +54,21 @@ test("it should create a collection", async () => {
   expect(collection2.metadata).toHaveProperty("test");
   expect(collection2.metadata).toEqual({ test: "test" });
   let collections2 = await chroma.listCollections();
-  expect([
-    {
-      name: "test2",
-      metadata: { test: "test" },
-      id: collection2.id,
-      database: "default_database",
-      tenant: "default_tenant",
-      dimension: null,
-      version: 0,
-    },
-  ]).toEqual(
-    expect.arrayContaining(
-      collections2.map(({ configuration_json, ...rest }) => rest),
-    ),
-  );
+  expect(collections2).toMatchInlineSnapshot(`
+    [
+      {
+        "database": "default_database",
+        "dimension": null,
+        "id": "${collection2.id}",
+        "metadata": {
+          "test": "test",
+        },
+        "name": "test2",
+        "tenant": "default_tenant",
+        "version": 0,
+      },
+    ]
+  `);
 });
 
 test("it should get a collection", async () => {

--- a/clients/js/test/collection.client.test.ts
+++ b/clients/js/test/collection.client.test.ts
@@ -1,5 +1,6 @@
 import { expect, test, beforeEach } from "@jest/globals";
 import chroma from "./initClient";
+import { DefaultEmbeddingFunction } from "../src/embeddings/DefaultEmbeddingFunction";
 
 beforeEach(async () => {
   await chroma.reset();
@@ -7,12 +8,11 @@ beforeEach(async () => {
 
 test("it should list collections", async () => {
   let collections = await chroma.listCollections();
-  expect(collections).toBeDefined();
-  expect(collections).toBeInstanceOf(Array);
-  expect(collections.length).toBe(0);
-  const collection = await chroma.createCollection({ name: "test" });
+  expect(Array.isArray(collections)).toBe(true);
+  expect(collections).toHaveLength(0);
+  await chroma.createCollection({ name: "test" });
   collections = await chroma.listCollections();
-  expect(collections.length).toBe(1);
+  expect(collections).toHaveLength(1);
 });
 
 test("it should create a collection", async () => {
@@ -75,7 +75,10 @@ test("it should create a collection", async () => {
 
 test("it should get a collection", async () => {
   const collection = await chroma.createCollection({ name: "test" });
-  const collection2 = await chroma.getCollection({ name: "test" });
+  const collection2 = await chroma.getCollection({
+    name: "test",
+    embeddingFunction: new DefaultEmbeddingFunction(),
+  });
   expect(collection).toBeDefined();
   expect(collection2).toBeDefined();
   expect(collection).toHaveProperty("name");

--- a/clients/js/test/collection.client.test.ts
+++ b/clients/js/test/collection.client.test.ts
@@ -22,19 +22,25 @@ test("it should create a collection", async () => {
   expect(collection).toHaveProperty("id");
   expect(collection.name).toBe("test");
   let collections = await chroma.listCollections();
+  expect(collections).toHaveLength(1);
 
-  expect(collections).toMatchInlineSnapshot(`
-    [
-      {
-        "database": "default_database",
-        "dimension": null,
-        "id": "${collection.id}",
-        "metadata": null,
-        "name": "test",
-        "tenant": "default_tenant",
-        "version": 0,
-      },
-    ]
+  const [returnedCollection] = collections;
+
+  expect({
+    ...returnedCollection,
+    configuration_json: undefined,
+    id: undefined,
+  }).toMatchInlineSnapshot(`
+    {
+      "configuration_json": undefined,
+      "database": "default_database",
+      "dimension": null,
+      "id": undefined,
+      "metadata": null,
+      "name": "test",
+      "tenant": "default_tenant",
+      "version": 0,
+    }
   `);
 
   expect([{ name: "test2", metadata: null }]).not.toEqual(
@@ -53,21 +59,26 @@ test("it should create a collection", async () => {
   expect(collection2).toHaveProperty("metadata");
   expect(collection2.metadata).toHaveProperty("test");
   expect(collection2.metadata).toEqual({ test: "test" });
-  let collections2 = await chroma.listCollections();
-  expect(collections2).toMatchInlineSnapshot(`
-    [
-      {
-        "database": "default_database",
-        "dimension": null,
-        "id": "${collection2.id}",
-        "metadata": {
-          "test": "test",
-        },
-        "name": "test2",
-        "tenant": "default_tenant",
-        "version": 0,
+  const collections2 = await chroma.listCollections();
+  expect(collections2).toHaveLength(1);
+  const [returnedCollection2] = collections2;
+  expect({
+    ...returnedCollection2,
+    configuration_json: undefined,
+    id: undefined,
+  }).toMatchInlineSnapshot(`
+    {
+      "configuration_json": undefined,
+      "database": "default_database",
+      "dimension": null,
+      "id": undefined,
+      "metadata": {
+        "test": "test",
       },
-    ]
+      "name": "test2",
+      "tenant": "default_tenant",
+      "version": 0,
+    }
   `);
 });
 

--- a/clients/js/test/collection.test.ts
+++ b/clients/js/test/collection.test.ts
@@ -64,7 +64,7 @@ test("it fails with a nice error when calling the legacy functions", async () =>
   const collection = await chroma.createCollection({ name: "test" });
   // @ts-ignore
   expect(collection.peek()).rejects.toThrowErrorMatchingInlineSnapshot(
-    `"Collection's methods have been moved to ChromaClient. Please use ChromaClient.peekRecords() instead."`,
+    `"Collection methods have been moved to ChromaClient. Please use ChromaClient.peekRecords() instead."`,
   );
 });
 

--- a/clients/js/test/collection.test.ts
+++ b/clients/js/test/collection.test.ts
@@ -1,17 +1,22 @@
 import { expect, test } from "@jest/globals";
 import chroma from "./initClient";
+import { DefaultEmbeddingFunction } from "../src/embeddings/DefaultEmbeddingFunction";
 
 test("it should modify collection", async () => {
   await chroma.reset();
   const collection = await chroma.createCollection({ name: "test" });
   expect(collection.name).toBe("test");
-  expect(collection.metadata).toBeUndefined();
+  expect(collection.metadata).toBeNull();
 
-  await collection.modify({ name: "test2" });
+  collection.name = "test2";
+  await chroma.updateCollection(collection);
   expect(collection.name).toBe("test2");
-  expect(collection.metadata).toBeUndefined();
+  expect(collection.metadata).toBeNull();
 
-  const collection2 = await chroma.getCollection({ name: "test2" });
+  const collection2 = await chroma.getCollection({
+    name: "test2",
+    embeddingFunction: new DefaultEmbeddingFunction(),
+  });
   expect(collection2.name).toBe("test2");
   expect(collection2.metadata).toBeNull();
 
@@ -29,21 +34,38 @@ test("it should modify collection", async () => {
   expect(collection3.name).toBe(original_name);
   expect(collection3.metadata).toEqual(original_metadata);
 
-  await collection3.modify({ name: new_name });
+  collection3.name = new_name;
+  await chroma.updateCollection(collection3);
   expect(collection3.name).toBe(new_name);
   expect(collection3.metadata).toEqual(original_metadata);
 
-  const collection4 = await chroma.getCollection({ name: new_name });
+  const collection4 = await chroma.getCollection({
+    name: new_name,
+    embeddingFunction: new DefaultEmbeddingFunction(),
+  });
   expect(collection4.name).toBe(new_name);
   expect(collection4.metadata).toEqual(original_metadata);
 
-  await collection3.modify({ metadata: new_metadata });
+  collection3.metadata = new_metadata;
+  await chroma.updateCollection(collection3);
   expect(collection3.name).toBe(new_name);
   expect(collection3.metadata).toEqual(new_metadata);
 
-  const collection5 = await chroma.getCollection({ name: new_name });
+  const collection5 = await chroma.getCollection({
+    name: new_name,
+    embeddingFunction: new DefaultEmbeddingFunction(),
+  });
   expect(collection5.name).toBe(new_name);
   expect(collection5.metadata).toEqual(new_metadata);
+});
+
+test("it fails with a nice error when calling the legacy functions", async () => {
+  await chroma.reset();
+  const collection = await chroma.createCollection({ name: "test" });
+  // @ts-ignore
+  expect(collection.peek()).rejects.toThrowErrorMatchingInlineSnapshot(
+    `"Collection's methods have been moved to ChromaClient. Please use ChromaClient.peekRecords() instead."`,
+  );
 });
 
 test("it should store metadata", async () => {
@@ -55,7 +77,10 @@ test("it should store metadata", async () => {
   expect(collection.metadata).toEqual({ test: "test" });
 
   // get the collection
-  const collection2 = await chroma.getCollection({ name: "test" });
+  const collection2 = await chroma.getCollection({
+    name: "test",
+    embeddingFunction: new DefaultEmbeddingFunction(),
+  });
   expect(collection2.metadata).toEqual({ test: "test" });
 
   // get or create the collection
@@ -63,10 +88,14 @@ test("it should store metadata", async () => {
   expect(collection3.metadata).toEqual({ test: "test" });
 
   // modify
-  await collection3.modify({ metadata: { test: "test2" } });
+  collection3.metadata = { test: "test2" };
+  await chroma.updateCollection(collection3);
   expect(collection3.metadata).toEqual({ test: "test2" });
 
   // get it again
-  const collection4 = await chroma.getCollection({ name: "test" });
+  const collection4 = await chroma.getCollection({
+    name: "test",
+    embeddingFunction: new DefaultEmbeddingFunction(),
+  });
   expect(collection4.metadata).toEqual({ test: "test2" });
 });

--- a/clients/js/test/delete.collection.test.ts
+++ b/clients/js/test/delete.collection.test.ts
@@ -3,23 +3,25 @@ import chroma from "./initClient";
 import { EMBEDDINGS, IDS, METADATAS } from "./data";
 import { InvalidCollectionError } from "../src/Errors";
 
-test("it should delete a collection", async () => {
+test("it should delete documents from a collection", async () => {
   await chroma.reset();
   const collection = await chroma.createCollection({ name: "test" });
-  await collection.add({
+  await chroma.addRecords(collection, {
     ids: IDS,
     embeddings: EMBEDDINGS,
     metadatas: METADATAS,
   });
-  let count = await collection.count();
+  let count = await chroma.countRecords(collection);
   expect(count).toBe(3);
-  var resp = await collection.delete({ where: { test: "test1" } });
-  count = await collection.count();
+  await chroma.deleteRecords(collection, {
+    where: { test: "test1" },
+  });
+  count = await chroma.countRecords(collection);
   expect(count).toBe(2);
 
-  var remainingEmbeddings = await collection.get();
-  expect(["test2", "test3"]).toEqual(
-    expect.arrayContaining(remainingEmbeddings.ids),
+  const remainingEmbeddings = await chroma.getRecords(collection);
+  expect(remainingEmbeddings?.ids).toEqual(
+    expect.arrayContaining(["test2", "test3"]),
   );
 });
 
@@ -28,6 +30,6 @@ test("should error on non existing collection", async () => {
   const collection = await chroma.createCollection({ name: "test" });
   await chroma.deleteCollection({ name: "test" });
   expect(async () => {
-    await collection.delete({ where: { test: "test1" } });
+    await chroma.deleteRecords(collection, { where: { test: "test1" } });
   }).rejects.toThrow(InvalidCollectionError);
 });

--- a/clients/js/test/get.collection.test.ts
+++ b/clients/js/test/get.collection.test.ts
@@ -2,42 +2,41 @@ import { expect, test } from "@jest/globals";
 import chroma from "./initClient";
 import { DOCUMENTS, EMBEDDINGS, IDS, METADATAS } from "./data";
 import { ChromaValueError, InvalidCollectionError } from "../src/Errors";
+import { DefaultEmbeddingFunction } from "../src/embeddings/DefaultEmbeddingFunction";
 
-test("it should get a collection", async () => {
+test("it should get documents from a collection", async () => {
   await chroma.reset();
   const collection = await chroma.createCollection({ name: "test" });
-  await collection.add({
+  await chroma.addRecords(collection, {
     ids: IDS,
     embeddings: EMBEDDINGS,
     metadatas: METADATAS,
   });
-  const results = await collection.get({ ids: ["test1"] });
-  expect(results).toBeDefined();
-  expect(results).toBeInstanceOf(Object);
-  expect(results.ids.length).toBe(1);
+  const results = await chroma.getRecords(collection, { ids: ["test1"] });
+  expect(results?.ids).toHaveLength(1);
   expect(["test1"]).toEqual(expect.arrayContaining(results.ids));
   expect(["test2"]).not.toEqual(expect.arrayContaining(results.ids));
   expect(results.included).toEqual(
     expect.arrayContaining(["metadatas", "documents"]),
   );
 
-  const results2 = await collection.get({ where: { test: "test1" } });
-  expect(results2).toBeDefined();
-  expect(results2).toBeInstanceOf(Object);
-  expect(results2.ids.length).toBe(1);
+  const results2 = await chroma.getRecords(collection, {
+    where: { test: "test1" },
+  });
+  expect(results2?.ids).toHaveLength(1);
   expect(["test1"]).toEqual(expect.arrayContaining(results2.ids));
 });
 
 test("wrong code returns an error", async () => {
   await chroma.reset();
   const collection = await chroma.createCollection({ name: "test" });
-  await collection.add({
+  await chroma.addRecords(collection, {
     ids: IDS,
     embeddings: EMBEDDINGS,
     metadatas: METADATAS,
   });
   try {
-    await collection.get({
+    await chroma.getRecords(collection, {
       where: {
         //@ts-ignore supposed to fail
         test: { $contains: "hello" },
@@ -55,49 +54,47 @@ test("wrong code returns an error", async () => {
 test("it should get embedding with matching documents", async () => {
   await chroma.reset();
   const collection = await chroma.createCollection({ name: "test" });
-  await collection.add({
+  await chroma.addRecords(collection, {
     ids: IDS,
     embeddings: EMBEDDINGS,
     metadatas: METADATAS,
     documents: DOCUMENTS,
   });
-  const results2 = await collection.get({
+  const results2 = await chroma.getRecords(collection, {
     whereDocument: { $contains: "This is a test" },
   });
-  expect(results2).toBeDefined();
-  expect(results2).toBeInstanceOf(Object);
-  expect(results2.ids.length).toBe(1);
+  expect(results2?.ids).toHaveLength(1);
   expect(["test1"]).toEqual(expect.arrayContaining(results2.ids));
 });
 
 test("it should get records not matching", async () => {
   await chroma.reset();
   const collection = await chroma.createCollection({ name: "test" });
-  await collection.add({
+  await chroma.addRecords(collection, {
     ids: IDS,
     embeddings: EMBEDDINGS,
     metadatas: METADATAS,
     documents: DOCUMENTS,
   });
-  const results2 = await collection.get({
+  const results2 = await chroma.getRecords(collection, {
     whereDocument: { $not_contains: "This is another" },
   });
-  expect(results2).toBeDefined();
-  expect(results2).toBeInstanceOf(Object);
-  expect(results2.ids.length).toBe(2);
+  expect(results2?.ids).toHaveLength(2);
   expect(["test1", "test3"]).toEqual(expect.arrayContaining(results2.ids));
 });
 
 test("test gt, lt, in a simple small way", async () => {
   await chroma.reset();
   const collection = await chroma.createCollection({ name: "test" });
-  await collection.add({
+  await chroma.addRecords(collection, {
     ids: IDS,
     embeddings: EMBEDDINGS,
     metadatas: METADATAS,
   });
-  const items = await collection.get({ where: { float_value: { $gt: -1.4 } } });
-  expect(items.ids.length).toBe(2);
+  const items = await chroma.getRecords(collection, {
+    where: { float_value: { $gt: -1.4 } },
+  });
+  expect(items.ids).toHaveLength(2);
   expect(["test2", "test3"]).toEqual(expect.arrayContaining(items.ids));
 });
 
@@ -106,7 +103,7 @@ test("should error on non existing collection", async () => {
   const collection = await chroma.createCollection({ name: "test" });
   await chroma.deleteCollection({ name: "test" });
   expect(async () => {
-    await collection.get({ ids: IDS });
+    await chroma.getRecords(collection, { ids: IDS });
   }).rejects.toThrow(InvalidCollectionError);
 });
 
@@ -114,6 +111,10 @@ test("it should throw an error if the collection does not exist", async () => {
   await chroma.reset();
 
   await expect(
-    async () => await chroma.getCollection({ name: "test" }),
+    async () =>
+      await chroma.getCollection({
+        name: "test",
+        embeddingFunction: new DefaultEmbeddingFunction(),
+      }),
   ).rejects.toThrow(Error);
 });

--- a/clients/js/test/offline.test.ts
+++ b/clients/js/test/offline.test.ts
@@ -10,7 +10,7 @@ test("it fails with a nice error", async () => {
   } catch (e) {
     expect(e).toBeInstanceOf(ChromaConnectionError);
     expect((e as Error).message).toMatchInlineSnapshot(
-      `"Error: ChromaConnectionError: Failed to connect to chromadb. Make sure your server is running and try again. If you are running from a browser, make sure that your chromadb instance is configured to allow requests from the current origin using the CHROMA_SERVER_CORS_ALLOW_ORIGINS environment variable., Could not connect to tenant default_tenant. Are you sure it exists?"`,
+      `"Failed to connect to chromadb. Make sure your server is running and try again. If you are running from a browser, make sure that your chromadb instance is configured to allow requests from the current origin using the CHROMA_SERVER_CORS_ALLOW_ORIGINS environment variable."`,
     );
   }
 });

--- a/clients/js/test/offline.test.ts
+++ b/clients/js/test/offline.test.ts
@@ -10,7 +10,7 @@ test("it fails with a nice error", async () => {
   } catch (e) {
     expect(e).toBeInstanceOf(ChromaConnectionError);
     expect((e as Error).message).toMatchInlineSnapshot(
-      `"Failed to connect to chromadb. Make sure your server is running and try again. If you are running from a browser, make sure that your chromadb instance is configured to allow requests from the current origin using the CHROMA_SERVER_CORS_ALLOW_ORIGINS environment variable."`,
+      `"Error: ChromaConnectionError: Failed to connect to chromadb. Make sure your server is running and try again. If you are running from a browser, make sure that your chromadb instance is configured to allow requests from the current origin using the CHROMA_SERVER_CORS_ALLOW_ORIGINS environment variable., Could not connect to tenant default_tenant. Are you sure it exists?"`,
     );
   }
 });

--- a/clients/js/test/peek.collection.test.ts
+++ b/clients/js/test/peek.collection.test.ts
@@ -6,10 +6,10 @@ import { InvalidCollectionError } from "../src/Errors";
 test("it should peek a collection", async () => {
   await chroma.reset();
   const collection = await chroma.createCollection({ name: "test" });
-  await collection.add({ ids: IDS, embeddings: EMBEDDINGS });
-  const results = await collection.peek({ limit: 2 });
+  await chroma.addRecords(collection, { ids: IDS, embeddings: EMBEDDINGS });
+  const results = await chroma.peekRecords(collection, { limit: 2 });
   expect(results).toBeDefined();
-  expect(results).toBeInstanceOf(Object);
+  expect(typeof results).toBe("object");
   expect(results.ids.length).toBe(2);
   expect(["test1", "test2"]).toEqual(expect.arrayContaining(results.ids));
 });
@@ -19,6 +19,6 @@ test("should error on non existing collection", async () => {
   const collection = await chroma.createCollection({ name: "test" });
   await chroma.deleteCollection({ name: "test" });
   expect(async () => {
-    await collection.peek();
+    await chroma.peekRecords(collection);
   }).rejects.toThrow(InvalidCollectionError);
 });

--- a/clients/js/test/query.collection.test.ts
+++ b/clients/js/test/query.collection.test.ts
@@ -23,12 +23,12 @@ test("it should query a collection, singular", async () => {
   const collection = await chroma.createCollection({ name: "test" });
   await chroma.addRecords(collection, { ids: IDS, embeddings: EMBEDDINGS });
   const results = await chroma.queryRecords(collection, {
-    query: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    queryEmbeddings: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
     nResults: 2,
   });
-  expect(results.ids).toHaveLength(2);
-  expect(results.ids).toEqual(expect.arrayContaining(["test1", "test2"]));
-  expect(results.ids).not.toContain("test3");
+  expect(results.ids[0]).toHaveLength(2);
+  expect(results.ids[0]).toEqual(expect.arrayContaining(["test1", "test2"]));
+  expect(results.ids[0]).not.toContain("test3");
   expect(results.included).toEqual(
     expect.arrayContaining(["metadatas", "documents"]),
   );
@@ -39,7 +39,7 @@ test("it should query a collection, array", async () => {
   const collection = await chroma.createCollection({ name: "test" });
   await chroma.addRecords(collection, { ids: IDS, embeddings: EMBEDDINGS });
   const results = await chroma.queryRecords(collection, {
-    query: [
+    queryEmbeddings: [
       [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
       [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
     ],
@@ -68,26 +68,26 @@ test("it should get embedding with matching documents", async () => {
   });
 
   const results = await chroma.queryRecords(collection, {
-    query: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    queryEmbeddings: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
     nResults: 3,
     whereDocument: { $contains: "This is a test" },
   });
 
   // it should only return doc1
-  expect(results?.ids).toHaveLength(1);
-  expect(results.ids).toContain("test1");
-  expect(results.ids).not.toContain("test2");
-  expect(results.documents).toContain("This is a test");
+  expect(results?.ids[0]).toHaveLength(1);
+  expect(results.ids[0]).toContain("test1");
+  expect(results.ids[0]).not.toContain("test2");
+  expect(results.documents[0]).toContain("This is a test");
 
   const results2 = await chroma.queryRecords(collection, {
-    query: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    queryEmbeddings: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
     nResults: 3,
     whereDocument: { $contains: "This is a test" },
     include: [IncludeEnum.Embeddings],
   });
 
-  expect(results2.embeddings?.length).toBe(1);
-  expect(results2.embeddings?.[0]).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+  expect(results2.embeddings?.[0]?.length).toBe(1);
+  expect(results2.embeddings?.[0][0]).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
   expect(results2.included).toEqual(expect.arrayContaining(["embeddings"]));
 });
 
@@ -102,14 +102,14 @@ test("it should exclude documents matching - not_contains", async () => {
   });
 
   const results = await chroma.queryRecords(collection, {
-    query: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    queryEmbeddings: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
     nResults: 3,
     whereDocument: { $not_contains: "This is a test" },
   });
 
   // it should only return doc1
-  expect(results?.ids).toHaveLength(2);
-  expect(results.ids).toEqual(expect.arrayContaining(["test2", "test3"]));
+  expect(results?.ids[0]).toHaveLength(2);
+  expect(results.ids[0]).toEqual(expect.arrayContaining(["test2", "test3"]));
 });
 
 // test queryTexts
@@ -128,15 +128,15 @@ test("it should query a collection with text", async () => {
   });
 
   const results = await chroma.queryRecords(collection, {
-    query: "test",
+    queryTexts: "test",
     nResults: 3,
     whereDocument: { $contains: "This is a test" },
   });
 
-  expect(results?.ids).toHaveLength(1);
-  expect(results.ids).toContain("test1");
-  expect(results.ids).not.toContain("test2");
-  expect(results.documents).toContain("This is a test");
+  expect(results?.ids[0]).toHaveLength(1);
+  expect(results.ids[0]).toContain("test1");
+  expect(results.ids[0]).not.toContain("test2");
+  expect(results.documents[0]).toContain("This is a test");
 });
 
 test("it should query a collection with text and where", async () => {
@@ -154,15 +154,15 @@ test("it should query a collection with text and where", async () => {
   });
 
   const results = await chroma.queryRecords(collection, {
-    query: "test",
+    queryTexts: "test",
     nResults: 3,
     where: { float_value: 2 },
   });
 
-  expect(results?.ids).toHaveLength(1);
-  expect(results.ids).toContain("test3");
-  expect(results.ids).not.toContain("test2");
-  expect(results.documents).toContain("This is a third test");
+  expect(results?.ids[0]).toHaveLength(1);
+  expect(results.ids[0]).toContain("test3");
+  expect(results.ids[0]).not.toContain("test2");
+  expect(results.documents[0]).toContain("This is a third test");
 });
 
 test("it should query a collection with text and where in", async () => {
@@ -180,15 +180,15 @@ test("it should query a collection with text and where in", async () => {
   });
 
   const results = await chroma.queryRecords(collection, {
-    query: "test",
+    queryTexts: "test",
     nResults: 3,
     where: { float_value: { $in: [2, 5, 10] } },
   });
 
-  expect(results.ids).toHaveLength(1);
-  expect(results.ids).toContain("test3");
-  expect(results.ids).not.toContain("test2");
-  expect(results.documents).toContain("This is a third test");
+  expect(results.ids[0]).toHaveLength(1);
+  expect(results.ids[0]).toContain("test3");
+  expect(results.ids[0]).not.toContain("test2");
+  expect(results.documents[0]).toContain("This is a third test");
 });
 
 test("it should query a collection with text and where nin", async () => {
@@ -205,33 +205,16 @@ test("it should query a collection with text and where nin", async () => {
   });
 
   const results = await chroma.queryRecords(collection, {
-    query: "test",
+    queryTexts: "test",
     nResults: 3,
     where: { float_value: { $nin: [-2, 0] } },
   });
 
   expect(results).toBeDefined();
-  expect(results.ids).toEqual(expect.arrayContaining(["test3"]));
-  expect(results.ids).not.toEqual(expect.arrayContaining(["test2"]));
-  expect(results.documents).toEqual(
+  expect(results.ids[0]).toEqual(expect.arrayContaining(["test3"]));
+  expect(results.ids[0]).not.toEqual(expect.arrayContaining(["test2"]));
+  expect(results.documents[0]).toEqual(
     expect.arrayContaining(["This is a third test"]),
-  );
-});
-
-test("should error on clients using queryTexts or queryEmbeddings", async () => {
-  await chroma.reset();
-  const collection = await chroma.createCollection({ name: "test" });
-  expect(async () => {
-    // @ts-ignore
-    await chroma.queryRecords(collection, { queryTexts: ["coolstuff"] });
-  }).rejects.toThrowErrorMatchingInlineSnapshot(
-    `"queryTexts and queryEmbeddings have been combined into a single query field which can accept either query strings or query embeddings."`,
-  );
-  expect(async () => {
-    // @ts-ignore
-    await chroma.queryRecords(collection, { queryEmbeddings: [2, 3] });
-  }).rejects.toThrowErrorMatchingInlineSnapshot(
-    `"queryTexts and queryEmbeddings have been combined into a single query field which can accept either query strings or query embeddings."`,
   );
 });
 
@@ -240,6 +223,6 @@ test("should error on non existing collection", async () => {
   const collection = await chroma.createCollection({ name: "test" });
   await chroma.deleteCollection({ name: "test" });
   expect(async () => {
-    await chroma.queryRecords(collection, { query: [1, 2, 3] });
+    await chroma.queryRecords(collection, { queryEmbeddings: [1, 2, 3] });
   }).rejects.toThrow(InvalidCollectionError);
 });

--- a/clients/js/test/update.collection.test.ts
+++ b/clients/js/test/update.collection.test.ts
@@ -7,45 +7,42 @@ import { InvalidCollectionError } from "../src/Errors";
 test("it should get embedding with matching documents", async () => {
   await chroma.reset();
   const collection = await chroma.createCollection({ name: "test" });
-  await collection.add({
+  await chroma.addRecords(collection, {
     ids: IDS,
     embeddings: EMBEDDINGS,
     metadatas: METADATAS,
     documents: DOCUMENTS,
   });
 
-  const results = await collection.get({
-    ids: ["test1"],
+  const results = await chroma.getRecords(collection, {
+    id: "test1",
     include: [
       IncludeEnum.Embeddings,
       IncludeEnum.Metadatas,
       IncludeEnum.Documents,
     ],
   });
-  expect(results).toBeDefined();
-  expect(results).toBeInstanceOf(Object);
-  expect(results.embeddings![0]).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
-  await collection.update({
+  expect(results?.embedding).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+  await chroma.updateRecords(collection, {
     ids: ["test1"],
     embeddings: [[1, 2, 3, 4, 5, 6, 7, 8, 9, 11]],
     metadatas: [{ test: "test1new" }],
     documents: ["doc1new"],
   });
 
-  const results2 = await collection.get({
-    ids: ["test1"],
+  const results2 = await chroma.getRecords(collection, {
+    id: "test1",
     include: [
       IncludeEnum.Embeddings,
       IncludeEnum.Metadatas,
       IncludeEnum.Documents,
     ],
   });
-  expect(results2).toBeDefined();
-  expect(results2).toBeInstanceOf(Object);
-  expect(results2.embeddings![0]).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 11]);
-  expect(results2.metadatas[0]).toEqual({ test: "test1new", float_value: -2 });
-  expect(results2.documents[0]).toEqual("doc1new");
+  expect(results2?.embedding).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 11]);
+  expect(results2.metadata).toEqual({ test: "test1new", float_value: -2 });
+  expect(results2.document).toEqual("doc1new");
 });
 
 test("should error on non existing collection", async () => {
@@ -53,7 +50,7 @@ test("should error on non existing collection", async () => {
   const collection = await chroma.createCollection({ name: "test" });
   await chroma.deleteCollection({ name: "test" });
   expect(async () => {
-    await collection.update({
+    await chroma.updateRecords(collection, {
       ids: ["test1"],
       embeddings: [[1, 2, 3, 4, 5, 6, 7, 8, 9, 11]],
       metadatas: [{ test: "meta1" }],

--- a/clients/js/test/upsert.collections.test.ts
+++ b/clients/js/test/upsert.collections.test.ts
@@ -10,8 +10,8 @@ test("it should upsert embeddings to a collection", async () => {
     [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
     [10, 9, 8, 7, 6, 5, 4, 3, 2, 1],
   ];
-  await collection.add({ ids, embeddings });
-  const count = await collection.count();
+  await chroma.addRecords(collection, { ids, embeddings });
+  const count = await chroma.countRecords(collection);
   expect(count).toBe(2);
 
   const ids2 = ["test2", "test3"];
@@ -20,9 +20,12 @@ test("it should upsert embeddings to a collection", async () => {
     [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
   ];
 
-  await collection.upsert({ ids: ids2, embeddings: embeddings2 });
+  await chroma.upsertRecords(collection, {
+    ids: ids2,
+    embeddings: embeddings2,
+  });
 
-  const count2 = await collection.count();
+  const count2 = await chroma.countRecords(collection);
   expect(count2).toBe(3);
 });
 
@@ -31,7 +34,7 @@ test("should error on non existing collection", async () => {
   const collection = await chroma.createCollection({ name: "test" });
   await chroma.deleteCollection({ name: "test" });
   expect(async () => {
-    await collection.upsert({
+    await chroma.upsertRecords(collection, {
       ids: ["test1"],
       embeddings: [[1, 2, 3, 4, 5, 6, 7, 8, 9, 11]],
       metadatas: [{ test: "meta1" }],


### PR DESCRIPTION
This PR is part of a series. See https://github.com/chroma-core/chroma/pull/2384 for the full context for this effort.